### PR TITLE
Update unpack.df.columns.R

### DIFF
--- a/R/unpack.df.columns.R
+++ b/R/unpack.df.columns.R
@@ -15,7 +15,7 @@
 # function for unpacking dataframes where columns also contain dataframes. It returns a dataframe with atomic columns
 
 ############
-unpack.df.columns <- function (df) 
+unpack.df.columns <- function (df, all_as_character = FALSE) 
 {
   `%notin%` <- Negate(`%in%`)
 # PREP  
@@ -92,6 +92,12 @@ unpack.df.columns <- function (df)
   
   names(df) <- names(df) %>%
     gsub("^_","",.) # underscore as first char
+  
+  
+  if(all_as_character = TRUE){
+    df <- df %>%
+      mutate_all(as.character)
+  }
 
     return(df)
 }


### PR DESCRIPTION
there's sometimes an error in R Studio when you try to view(df):
#_____________
Error in seq.int(z$l, z$u, length.out = z$n + 1) : 
  'to' must be a finite number
#__________
By forcing all columns to be as.character, it makes it possible to view the df. Not ideal, but it's quick.